### PR TITLE
remove snakebyte controller support

### DIFF
--- a/controller/client.py
+++ b/controller/client.py
@@ -63,8 +63,7 @@ def connect_to_server(client_socket: socket.socket, hostname: str, port: int):
         if len(data) == 0:  # did not receive any data, server prob closed
             break
 
-        event_info: list[int] = pickle.loads(data)
-        [event_type, code, value] = event_info
+        (event_type, code, value) = pickle.loads(data)
         react_to_event(event_type, code, value)
 
 

--- a/controller/server.py
+++ b/controller/server.py
@@ -26,8 +26,10 @@ def read_joystick(client_socket: socket.socket):
     for event in controller.read_loop():
         # we do not care about the time of the event, therefore sending this list[int]
         # instead of an InputEvent takes each pickle from ~104 bytes to 22-23 in tests
-        data = [event.type, event.code, event.value]
-        if sum(data) != 0:  # all-zero events are ignored
+        data = (event.type, event.code, event.value)
+        if (  # all-zero events and event types 2 and 4 are ignored.
+            sum(data) != 0 and event.type % 2 != 0
+        ):
             client_socket.sendall(pickle.dumps(data))
 
 

--- a/controller/util.py
+++ b/controller/util.py
@@ -8,19 +8,19 @@ from evdev import ecodes
 
 
 def button_north(code: int) -> bool:
-    return code == ecodes.ecodes["BTN_NORTH"] or code == ecodes.ecodes["BTN_BASE2"]
+    return code == ecodes.ecodes["BTN_NORTH"]
 
 
 def button_east(code: int) -> bool:
-    return code == ecodes.ecodes["BTN_EAST"] or code == ecodes.ecodes["BTN_BASE3"]
+    return code == ecodes.ecodes["BTN_EAST"]
 
 
 def button_south(code: int) -> bool:
-    return code == ecodes.ecodes["BTN_SOUTH"] or code == ecodes.ecodes["BTN_BASE4"]
+    return code == ecodes.ecodes["BTN_SOUTH"]
 
 
 def button_west(code: int) -> bool:
-    return code == ecodes.ecodes["BTN_WEST"] or code == ecodes.ecodes["BTN_BASE5"]
+    return code == ecodes.ecodes["BTN_WEST"]
 
 
 def button_lbumper(code: int) -> bool:
@@ -64,12 +64,16 @@ def joy_left_y(code: int) -> bool:
 
 
 def joy_right_x(code: int) -> bool:
-    # TODO: snakebyte controller uses the Z's for right joystick, but my off-brand
-    # sony one at home uses Z's for triggers so maybe make this swappable?
-    return code == ecodes.ecodes["ABS_RX"] or code == ecodes.ecodes["ABS_Z"]
+    return code == ecodes.ecodes["ABS_RX"]
 
 
 def joy_right_y(code: int) -> bool:
-    # TODO: snakebyte controller uses the Z's for right joystick, but my off-brand
-    # sony one at home uses Z's for triggers so maybe make this swappable?
-    return code == ecodes.ecodes["ABS_RY"] or code == ecodes.ecodes["ABS_RZ"]
+    return code == ecodes.ecodes["ABS_RY"]
+
+
+def pressure_ltrigger(code: int) -> bool:
+    return code == ecodes.ecodes["ABS_Z"]
+
+
+def pressure_rtrigger(code: int) -> bool:
+    return code == ecodes.ecodes["ABS_RZ"]


### PR DESCRIPTION
makes things hard, we shall just support an xbox controller and the like instead for now.

misc: also ignore events `2` and `4` because 2 is for mice and 4 is misc, which we do not handle at the moment.